### PR TITLE
Header remanié pour un meilleur affichage en mode desktop & mobile

### DIFF
--- a/mon_projet/src/js/components/Header.jsx
+++ b/mon_projet/src/js/components/Header.jsx
@@ -1,40 +1,60 @@
 import { useState } from "react";
-import { Menu, User, LogOut } from "lucide-react";
+// Librairie d'icônes
+import {
+  LogOut,
+  Menu,
+  PanelTopClose,
+  PanelBottomOpen,
+  User,
+  X } from "lucide-react";
 import { Link } from "react-router-dom";
 
 const Header = () => {
+  // useState pour gérer l'état (ouvert/fermé) du menu
   const [isOpen, setIsOpen] = useState(false);
-  const toggleMenu = () => setIsOpen(!isOpen);
+  // 
+  const [switchIcon, setSwitchIcon] = useState(false);
+  // Fonction fléchée qui altère l'état du menu (du useState)
+  const toggleMenu = () => {
+    setIsOpen(!isOpen);
+    setSwitchIcon(!switchIcon);
+  }
+
+  const notImplemented = () => {
+    alert('Fonction en cours d\'implémentation')
+  }
 
   return (
-    <header className="bg-white shadow-sm fixed-top">
+    <header className="bg-white shadow fixed-top">
       <nav className="navbar navbar-expand-md container py-2">
-        <img src="../../data/logo/iconBlue.svg" width={64} height={64} className="ms-5" />
-        <Link to='/' className="navbar-link link fw-bold fs-5 text-primary ms-3">
+        <Link to="/"><img src="../../data/logo/iconBlue.svg" width={64} height={64} className="ms-3" /></Link>
+        <Link to='/' className="navbar-link link fw-bold fs-5 ms-md-3 d-md-block d-none">
           iziMOD | VOTRE Marketplace
         </Link>
 
         <button
-          className="navbar-toggler"
-          type="button"
+          className="bg-white me-3 text-black border-0 mb-3"
           onClick={toggleMenu}
-          aria-label="Toggle navigation"
+          aria-label="Ouvrir le menu"
         >
-          <span className="navbar-toggler-icon">
-            <Menu size={28} />
+          <span className="d-md-none">
+            {switchIcon && isOpen ? <X /> : <Menu />}
           </span>
         </button>
 
-        <div className={`collapse navbar-collapse ${isOpen ? "show" : "login"}`}>
-          <ul className="navbar-nav ms-auto me-5 mb-2 mb-md-0">
-            <li className="nav-item">
-              <a className="nav-link" href="login">
-                < User />
-              </a>
+        <div className={`collapse navbar-collapse ${isOpen ? "show" : ""}`}>
+          <ul className="navbar-nav ms-md-auto me-3 ms-3 mb-3 mb-md-0">
+            <li className="navbar-brand my-3">
+                <Link to="/" className="navbar-link link d-md-none fw-bold">iziMOD | VOTRE Marketplace</Link>
             </li>
             <li className="nav-item">
+              <a className="nav-link" href="login">
+                < User /> <span className="d-md-none">Connexion</span>
+              </a>
+            </li>
+            <li className="nav-item" onClick={notImplemented}>
               <a className="nav-link" href="#">
-                <LogOut />
+                <LogOut /> <span className="d-md-none">Déconnexion</span>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
Ajout des règles de media queries de Bootstrap pour un meilleur affichage du menu et du Header en général

Version desktop :
<img width="854" alt="Screenshot 2025-04-28 at 7 11 04 PM" src="https://github.com/user-attachments/assets/0547ec57-46a7-4854-b782-2a9488582b34" />

Version mobile (menu fermé) :
<img width="499" alt="Screenshot 2025-04-28 at 7 11 29 PM" src="https://github.com/user-attachments/assets/1486ad25-9a15-4357-b0ec-d934dd1ca4bd" />

Version mobile (menu ouvert) :
<img width="499" alt="Screenshot 2025-04-28 at 7 11 36 PM" src="https://github.com/user-attachments/assets/c59845c8-18bf-4108-8563-85a54fcedbc1" />
